### PR TITLE
feat: harden server with validation, file size limits and results endpoint

### DIFF
--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+  "env": {
+    "node": true,
+    "commonjs": true,
+    "jest": true,
+    "es2021": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2021
+  },
+  "rules": {
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    "no-console": "off"
+  }
+}

--- a/server/__tests__/server.test.js
+++ b/server/__tests__/server.test.js
@@ -1,5 +1,17 @@
 const request = require('supertest');
+const path = require('path');
+const fs = require('fs');
 const app = require('../index');
+
+const uploadsDir = path.join(__dirname, '..', 'uploads');
+
+function cleanUploads() {
+  fs.readdirSync(uploadsDir).forEach((file) => {
+    if (file !== '.gitkeep') fs.unlinkSync(path.join(uploadsDir, file));
+  });
+}
+
+afterAll(cleanUploads);
 
 describe('GET /', () => {
   it('should return health check message', async () => {
@@ -10,9 +22,88 @@ describe('GET /', () => {
 });
 
 describe('POST /upload', () => {
+  afterEach(cleanUploads);
+
+  it('should upload a video file successfully', async () => {
+    const res = await request(app)
+      .post('/upload')
+      .attach('video', Buffer.from('fake video content'), {
+        filename: 'test.mp4',
+        contentType: 'video/mp4',
+      });
+    expect(res.statusCode).toBe(201);
+    expect(res.body.message).toBe('Upload successful');
+    expect(res.body.filename).toBeDefined();
+  });
+
   it('should return 400 when no file is uploaded', async () => {
     const res = await request(app).post('/upload');
     expect(res.statusCode).toBe(400);
-    expect(res.body.message).toBe('No file uploaded');
+    expect(res.body.error).toBe('No file uploaded');
+  });
+
+  it('should reject non-video files with 415', async () => {
+    const res = await request(app)
+      .post('/upload')
+      .attach('video', Buffer.from('not a video'), {
+        filename: 'readme.txt',
+        contentType: 'text/plain',
+      });
+    expect(res.statusCode).toBe(415);
+    expect(res.body.error).toBe('Only video files are allowed.');
+  });
+});
+
+describe('GET /uploads', () => {
+  beforeAll(async () => {
+    cleanUploads();
+    await request(app)
+      .post('/upload')
+      .attach('video', Buffer.from('fake video'), {
+        filename: 'list-test.mp4',
+        contentType: 'video/mp4',
+      });
+  });
+
+  afterAll(cleanUploads);
+
+  it('should list uploaded files', async () => {
+    const res = await request(app).get('/uploads');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body.uploads)).toBe(true);
+    expect(res.body.uploads.length).toBeGreaterThanOrEqual(1);
+    expect(res.body.uploads[0]).toHaveProperty('filename');
+    expect(res.body.uploads[0]).toHaveProperty('hasResults');
+  });
+});
+
+describe('GET /results/:id', () => {
+  let uploadedFilename;
+
+  beforeAll(async () => {
+    const res = await request(app)
+      .post('/upload')
+      .attach('video', Buffer.from('fake video'), {
+        filename: 'result-test.mp4',
+        contentType: 'video/mp4',
+      });
+    uploadedFilename = res.body.filename;
+  });
+
+  afterAll(cleanUploads);
+
+  it('should return results for a valid id', async () => {
+    const res = await request(app).get(`/results/${uploadedFilename}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.id).toBe(uploadedFilename);
+    expect(res.body.status).toBe('processed');
+    expect(Array.isArray(res.body.highlights)).toBe(true);
+    expect(res.body.highlights.length).toBe(2);
+  });
+
+  it('should return 404 for an unknown id', async () => {
+    const res = await request(app).get('/results/nonexistent-file.mp4');
+    expect(res.statusCode).toBe(404);
+    expect(res.body.error).toBe('No results found for this id.');
   });
 });

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,9 @@ const fs = require('fs');
 const app = express();
 const port = process.env.PORT || 3000;
 
+// In-memory store for highlight results (keyed by filename)
+const results = new Map();
+
 // Create uploads directory if it doesn't exist
 const uploadDir = path.join(__dirname, 'uploads');
 if (!fs.existsSync(uploadDir)) {
@@ -22,22 +25,84 @@ const storage = multer.diskStorage({
     cb(null, uniqueSuffix + '-' + file.originalname);
   }
 });
-const upload = multer({ storage: storage });
+
+const fileFilter = function (req, file, cb) {
+  if (file.mimetype.startsWith('video/')) {
+    cb(null, true);
+  } else {
+    cb(new multer.MulterError('LIMIT_UNEXPECTED_FILE', 'video'), false);
+  }
+};
+
+const upload = multer({
+  storage,
+  fileFilter,
+  limits: { fileSize: 500 * 1024 * 1024 } // 500 MB
+});
 
 app.use(express.json());
 
-// Upload endpoint
-app.post('/upload', upload.single('video'), (req, res) => {
-  if (!req.file) {
-    return res.status(400).json({ message: 'No file uploaded' });
-  }
-  // In a real implementation, you'd send the file to the ML pipeline here
-  return res.json({ message: 'Upload erfolgreich', filename: req.file.filename });
+// Upload endpoint with multer error handling
+app.post('/upload', (req, res, next) => {
+  upload.single('video')(req, res, (err) => {
+    if (err) {
+      if (err instanceof multer.MulterError) {
+        if (err.code === 'LIMIT_FILE_SIZE') {
+          return res.status(413).json({ error: 'File too large. Maximum size is 500 MB.' });
+        }
+        if (err.code === 'LIMIT_UNEXPECTED_FILE') {
+          return res.status(415).json({ error: 'Only video files are allowed.' });
+        }
+        return res.status(400).json({ error: err.message });
+      }
+      return next(err);
+    }
+    if (!req.file) {
+      return res.status(400).json({ error: 'No file uploaded' });
+    }
+
+    // Store dummy highlight results for now
+    results.set(req.file.filename, {
+      id: req.file.filename,
+      status: 'processed',
+      highlights: [
+        { timestamp: 1.23, label: 'Kill', confidence: 0.95 },
+        { timestamp: 3.45, label: 'Objective', confidence: 0.87 },
+      ],
+    });
+
+    return res.status(201).json({ message: 'Upload successful', filename: req.file.filename });
+  });
 });
 
-// Simple health check
+// List uploaded videos
+app.get('/uploads', (req, res) => {
+  const files = fs.readdirSync(uploadDir).filter((f) => f !== '.gitkeep');
+  const uploads = files.map((filename) => ({
+    filename,
+    hasResults: results.has(filename),
+  }));
+  res.json({ uploads });
+});
+
+// Get highlight results for a video
+app.get('/results/:id', (req, res) => {
+  const data = results.get(req.params.id);
+  if (!data) {
+    return res.status(404).json({ error: 'No results found for this id.' });
+  }
+  return res.json(data);
+});
+
+// Health check
 app.get('/', (req, res) => {
   res.json({ message: 'Mobile Insights Server ist online' });
+});
+
+// Error-handling middleware
+app.use((err, _req, res, _next) => {
+  console.error(err);
+  res.status(500).json({ error: 'Internal server error' });
 });
 
 if (require.main === module) {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,7 +12,7 @@
         "multer": "^2.1.1"
       },
       "devDependencies": {
-        "eslint": "^8.56.0",
+        "eslint": "^8.57.1",
         "jest": "^29.7.0",
         "supertest": "^6.3.3"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
     "multer": "^2.1.1"
   },
   "devDependencies": {
-    "eslint": "^8.56.0",
+    "eslint": "^8.57.1",
     "jest": "^29.7.0",
     "supertest": "^6.3.3"
   }


### PR DESCRIPTION
## Beschreibung
Server gehärtet mit Validierung, Dateigrößenlimits und neuen Endpoints.

Closes #1

## Änderungen
- Multer `fileFilter`: nur `video/*` MIME-types akzeptiert (415 bei Ablehnung)
- 500 MB Dateigrößenlimit via multer limits (413 bei Überschreitung)
- `GET /results/:id` Endpoint mit In-Memory Dummy-Highlight-Daten
- `GET /uploads` Endpoint listet Videos mit Result-Status
- Error-Handling Middleware für saubere JSON-Fehlerantworten
- ESLint konfiguriert (`.eslintrc.json`) mit node/jest/commonjs env

## Komponente(n)
- [x] Server (`server/`)

## Checkliste
- [x] Code folgt den Projektkonventionen
- [x] Tests hinzugefügt/aktualisiert (7 Tests, alle grün)
- [x] CI ist grün
- [x] Copilot Review angefordert