### PR TITLE
chore: add Docker setup for local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+**/node_modules
+.git
+.github
+.venv
+__pycache__
+*.pyc
+mobile_app
+server/uploads
+server/__tests__
+ml/tests
+ml/.pytest_cache
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:20-slim
+
+# Install Python 3 and OpenCV system dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      python3 python3-pip python3-venv \
+      libgl1 libglib2.0-0 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Node.js dependencies
+COPY server/package.json server/package-lock.json* ./server/
+RUN cd server && npm ci --omit=dev
+
+# Install Python dependencies
+COPY ml/requirements.txt ./ml/
+RUN pip3 install --no-cache-dir --break-system-packages -r ml/requirements.txt
+
+# Copy application code
+COPY server/ ./server/
+COPY ml/ ./ml/
+
+RUN mkdir -p server/uploads
+
+EXPOSE 3000
+
+WORKDIR /app/server
+CMD ["node", "index.js"]

--- a/README.md
+++ b/README.md
@@ -58,3 +58,32 @@ mobile_insights_project/
 
 ## Hinweis
 Die mobile App ist in diesem Repository noch nicht implementiert, da sie native Bibliotheken und ein mobiles Build‑System voraussetzt. Sie soll später als separater Ordner im Unterverzeichnis `mobile_app` entstehen.
+
+## Docker
+
+The entire stack (server + ML pipeline) can be started with Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+This builds a single image containing both the Node.js server and Python ML dependencies.
+The server is available at `http://localhost:3000`.
+
+To stop:
+```bash
+docker compose down
+```
+
+### Individual Dockerfiles
+
+Standalone images for each component are also available:
+
+```bash
+# Server only
+docker build -t insights-server -f server/Dockerfile server/
+
+# ML pipeline only
+docker build -t insights-ml -f ml/Dockerfile ml/
+docker run --rm -v $(pwd)/uploads:/data insights-ml --video /data/video.mp4 --format json --output /data/results.json
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      - PORT=3000
+      - PYTHON_BIN=python3
+    volumes:
+      - uploads:/app/server/uploads
+
+volumes:
+  uploads:

--- a/ml/.dockerignore
+++ b/ml/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__
+*.pyc
+.pytest_cache
+tests/
+.venv/
+*.egg-info

--- a/ml/Dockerfile
+++ b/ml/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+# OpenCV requires libgl and libglib
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libgl1 libglib2.0-0 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT ["python", "highlight_detector.py"]

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log*
+uploads/
+__tests__
+.eslintrc.json

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev
+
+COPY . .
+
+RUN mkdir -p uploads
+
+EXPOSE 3000
+
+CMD ["node", "index.js"]


### PR DESCRIPTION
## Summary
Adds Docker setup for local development so the full stack (server + ML pipeline) can run without installing dependencies manually (Issue #5).

## Changes
- **Root Dockerfile**: Combined Node.js 20 + Python 3 image — server spawns ML pipeline directly
- **server/Dockerfile**: Standalone server image (Node 20-slim)
- **ml/Dockerfile**: Standalone ML image (Python 3.11-slim + OpenCV deps)
- **docker-compose.yml**: Single `app` service with shared `uploads` volume
- **.dockerignore** files: Root, server, and ML contexts — excludes tests, node_modules, .venv
- **README.md**: Docker usage docs (compose up, standalone builds)

## Architecture Note
Since the server spawns the Python ML pipeline via `child_process.spawn()`, the compose setup uses a single combined image. The individual Dockerfiles are available for standalone use or future microservice splitting.

## Testing
- Docker daemon was not running locally, but Dockerfiles have been manually verified for syntax
- CI workflows are not affected (no Docker workflow yet)

Closes #5