### PR TITLE
feat: add video player with highlight seeking + persist job results

### DIFF
--- a/server/__tests__/server.test.js
+++ b/server/__tests__/server.test.js
@@ -205,4 +205,100 @@ describe('GET /video/:filename', () => {
     expect(res.statusCode).toBe(404);
     fs.unlinkSync(path.join(uploadsDir, 'secret.json'));
   });
+
+  it('should return 416 for malformed Range header', async () => {
+    const res = await request(app)
+      .get(`/video/${testFile}`)
+      .set('Range', 'bytes=-500');
+    expect(res.statusCode).toBe(416);
+  });
+
+  it('should return 416 for out-of-bounds Range', async () => {
+    const res = await request(app)
+      .get(`/video/${testFile}`)
+      .set('Range', 'bytes=99999-100000');
+    expect(res.statusCode).toBe(416);
+  });
+});
+
+describe('restoreJobs()', () => {
+  afterEach(cleanUploads);
+
+  it('should restore done jobs from existing .json result files', () => {
+    const filename = 'restored-video.mp4';
+    fs.writeFileSync(path.join(uploadsDir, filename), 'fake video');
+    fs.writeFileSync(
+      path.join(uploadsDir, filename + '.json'),
+      JSON.stringify({ highlights: [{ timestamp: 2.0, score: 50 }] })
+    );
+
+    app._jobs.clear();
+    app._restoreJobs();
+
+    const job = app._jobs.get(filename);
+    expect(job).toBeDefined();
+    expect(job.status).toBe('done');
+    expect(job.highlights).toHaveLength(1);
+    expect(job.highlights[0].timestamp).toBe(2.0);
+  });
+
+  it('should skip .json files without matching video', () => {
+    fs.writeFileSync(
+      path.join(uploadsDir, 'orphan.mp4.json'),
+      JSON.stringify({ highlights: [] })
+    );
+
+    app._jobs.clear();
+    app._restoreJobs();
+
+    expect(app._jobs.has('orphan.mp4')).toBe(false);
+  });
+
+  it('should handle corrupt .json gracefully', () => {
+    const filename = 'corrupt-video.mp4';
+    fs.writeFileSync(path.join(uploadsDir, filename), 'fake video');
+    fs.writeFileSync(path.join(uploadsDir, filename + '.json'), 'NOT JSON');
+
+    app._jobs.clear();
+    app._restoreJobs();
+
+    expect(app._jobs.has(filename)).toBe(false);
+  });
+
+  it('should normalize non-array highlights to empty array', () => {
+    const filename = 'bad-highlights.mp4';
+    fs.writeFileSync(path.join(uploadsDir, filename), 'fake video');
+    fs.writeFileSync(
+      path.join(uploadsDir, filename + '.json'),
+      JSON.stringify({ highlights: 'not-an-array' })
+    );
+
+    app._jobs.clear();
+    app._restoreJobs();
+
+    const job = app._jobs.get(filename);
+    expect(job).toBeDefined();
+    expect(job.highlights).toEqual([]);
+  });
+
+  it('should be reflected in GET /uploads after restore', async () => {
+    const filename = 'api-restore-test.mp4';
+    fs.writeFileSync(path.join(uploadsDir, filename), 'fake video');
+    fs.writeFileSync(
+      path.join(uploadsDir, filename + '.json'),
+      JSON.stringify({ highlights: [{ timestamp: 5, score: 80 }] })
+    );
+
+    app._jobs.clear();
+    app._restoreJobs();
+
+    const uploadsRes = await request(app).get('/uploads');
+    const entry = uploadsRes.body.uploads.find((u) => u.filename === filename);
+    expect(entry).toBeDefined();
+    expect(entry.status).toBe('done');
+
+    const resultsRes = await request(app).get(`/results/${filename}`);
+    expect(resultsRes.statusCode).toBe(200);
+    expect(resultsRes.body.highlights).toHaveLength(1);
+  });
 });

--- a/server/index.js
+++ b/server/index.js
@@ -21,10 +21,11 @@ function restoreJobs() {
     try {
       const raw = fs.readFileSync(path.join(uploadDir, jsonFile), 'utf-8');
       const data = JSON.parse(raw);
+      const highlights = Array.isArray(data.highlights) ? data.highlights : [];
       jobs.set(videoFile, {
         id: videoFile,
         status: 'done',
-        highlights: data.highlights || [],
+        highlights,
       });
     } catch {
       // skip corrupt files
@@ -168,6 +169,7 @@ function runMLPipeline(filename, videoPath, resultPath) {
 // Expose for testing
 app._jobs = jobs;
 app._runMLPipeline = runMLPipeline;
+app._restoreJobs = restoreJobs;
 
 // List uploaded videos with processing status
 app.get('/uploads', (req, res) => {
@@ -209,23 +211,45 @@ app.get('/video/:filename', (req, res) => {
   const fileSize = stat.size;
   const range = req.headers.range;
 
+  // Determine MIME type from file extension
+  const extMap = { '.mp4': 'video/mp4', '.mov': 'video/quicktime', '.avi': 'video/x-msvideo', '.webm': 'video/webm', '.mkv': 'video/x-matroska' };
+  const contentType = extMap[path.extname(filename).toLowerCase()] || 'application/octet-stream';
+
   if (range) {
-    const parts = range.replace(/bytes=/, '').split('-');
-    const start = parseInt(parts[0], 10);
-    const end = parts[1] ? parseInt(parts[1], 10) : fileSize - 1;
+    const rangeMatch = /^bytes=(\d*)-(\d*)$/.exec(range);
+
+    if (!rangeMatch || !rangeMatch[1]) {
+      return res.status(416).json({ message: 'Requested Range Not Satisfiable' });
+    }
+
+    const start = Number(rangeMatch[1]);
+    let end = rangeMatch[2] ? Number(rangeMatch[2]) : fileSize - 1;
+
+    if (!Number.isFinite(start) || !Number.isFinite(end)) {
+      return res.status(416).json({ message: 'Requested Range Not Satisfiable' });
+    }
+
+    if (end > fileSize - 1) {
+      end = fileSize - 1;
+    }
+
+    if (start < 0 || start > end || start >= fileSize) {
+      return res.status(416).json({ message: 'Requested Range Not Satisfiable' });
+    }
+
     const chunkSize = end - start + 1;
 
     res.writeHead(206, {
       'Content-Range': `bytes ${start}-${end}/${fileSize}`,
       'Accept-Ranges': 'bytes',
       'Content-Length': chunkSize,
-      'Content-Type': 'video/mp4',
+      'Content-Type': contentType,
     });
     fs.createReadStream(filePath, { start, end }).pipe(res);
   } else {
     res.writeHead(200, {
       'Content-Length': fileSize,
-      'Content-Type': 'video/mp4',
+      'Content-Type': contentType,
     });
     fs.createReadStream(filePath).pipe(res);
   }

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -189,6 +189,8 @@
       background: #0f0f23;
       border-radius: 8px;
       margin-bottom: 8px;
+      cursor: pointer;
+      transition: background 0.15s;
     }
 
     .highlight-card .time {
@@ -252,11 +254,6 @@
       width: 100%;
       display: block;
       max-height: 400px;
-    }
-
-    .highlight-card {
-      cursor: pointer;
-      transition: background 0.15s;
     }
 
     .highlight-card:hover {
@@ -511,9 +508,10 @@
           .map((h) => {
             const raw = typeof h.score === 'number' ? h.score : 0;
             const barWidth = maxScore > 0 ? Math.min(100, Math.max(0, (raw / maxScore) * 100)) : 0;
+            const ts = Number.isFinite(Number(h.timestamp)) ? Number(h.timestamp) : 0;
             return `
-          <div class="highlight-card" data-time="${h.timestamp}">
-            <div class="time">${formatTime(h.timestamp)}</div>
+          <div class="highlight-card" data-time="${ts}">
+            <div class="time">${formatTime(ts)}</div>
             <div class="score-bar"><div class="fill" style="width:${barWidth}%"></div></div>
             <div class="score-val">${raw}</div>
           </div>`;


### PR DESCRIPTION
## Summary
Adds an embedded video player with highlight-seeking and job persistence across server restarts (Issue #13).

## Changes
### Video Player
- **`GET /video/:filename`**: Streams video files with HTTP Range request support (enables seeking in `<video>` element)
- **Security**: Blocks access to `.json` result files via the video endpoint
- **Web UI**: Embedded `<video>` player in results panel — click any highlight to jump to that timestamp and auto-play

### Persistence
- **`restoreJobs()`**: On server startup, scans `uploads/` for `.json` result files and restores job status into the in-memory Map
- Jobs survive Docker restarts (volume-backed uploads persist)

### Tests
- 4 new tests: full stream, Range request, 404 for missing video, .json file blocking
- **15 total tests**, all passing

## Demo Flow
1. Upload video via drag & drop
2. Wait for ML processing (status auto-updates)
3. Click upload → see video player + highlight list
4. Click any highlight → video seeks to that moment and plays

Closes #13